### PR TITLE
Changed private column to be default false and null false on TimeableObject model

### DIFF
--- a/db/migrate/20220506012312_change_private_on_timeable_object.rb
+++ b/db/migrate/20220506012312_change_private_on_timeable_object.rb
@@ -1,0 +1,5 @@
+class ChangePrivateOnTimeableObject < ActiveRecord::Migration[6.0]
+  def change
+    change_column :timeable_objects, :private, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_11_221135) do
+ActiveRecord::Schema.define(version: 2022_05_06_012312) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,7 +88,7 @@ ActiveRecord::Schema.define(version: 2021_09_11_221135) do
     t.string "map_id"
     t.bigint "interval"
     t.string "name"
-    t.boolean "private"
+    t.boolean "private", default: false, null: false
     t.index ["user_id"], name: "index_timeable_objects_on_user_id"
   end
 


### PR DESCRIPTION
Before running `rails db:migrate`, run:

`rails c`
`irb> TimeableObject.where(private: nil).each { |obj| obj.update(private: false) }`
`irb> quit`

So it prevents an error caused by records having null values

card: TimeableObject.where(private: nil).each { |obj| obj.update(private: false) }